### PR TITLE
features to support nmesh program at Florida Atlantic University

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ CFLAGS = -std=c99 -fPIC -pedantic $(shell gsl-config --cflags)
 LFLAGS = $(shell gsl-config --libs)
 
 CFLAGS += -O3
+CFLAGS += -Wall
 
 # old flag information [Leave alone]
 ##CFLAGS + =`gsl-config --cflags`# GSL

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CFLAGS = -std=c99 -fPIC -pedantic $(shell gsl-config --cflags)
 LFLAGS = $(shell gsl-config --libs)
 
 CFLAGS += -O3
-CFLAGS += -Wall -Wwrite-strings
+CFLAGS += -Wall -Wwrite-strings -Wshadow
 
 # old flag information [Leave alone]
 ##CFLAGS + =`gsl-config --cflags`# GSL

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CFLAGS = -std=c99 -fPIC -pedantic $(shell gsl-config --cflags)
 LFLAGS = $(shell gsl-config --libs)
 
 CFLAGS += -O3
-CFLAGS += -Wall
+CFLAGS += -Wall -Wwrite-strings
 
 # old flag information [Leave alone]
 ##CFLAGS + =`gsl-config --cflags`# GSL

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,12 @@ CC = gcc
 LD = ld
 AR = ar
 
-CFLAGS = -std=c99 -fPIC -pedantic $(shell gsl-config --cflags)
+CFLAGS = -std=c11 -fPIC -pedantic $(shell gsl-config --cflags)
 LFLAGS = $(shell gsl-config --libs)
 
 CFLAGS += -O3
 CFLAGS += -Wall -Wwrite-strings -Wshadow
+CFLAGS += -Wpointer-arith -Wcast-qual -Wcast-align -Wnested-externs -fshort-enums -fno-common
 
 # old flag information [Leave alone]
 ##CFLAGS + =`gsl-config --cflags`# GSL

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -311,6 +311,36 @@ extern "C" {
    double *kyz,
    double *kzz);
 
+  void TwoPunctures_Cartesian_interpolation_list
+  (ini_data *data,    // struct containing the previously calculated solution
+   int np,            // number of elements in each array that follows...
+   const double *px,  // coordinates of interpolation points
+   const double *py,
+   const double *pz,
+   double *alp,       // lapse
+   double *psi,       // conformal factor and derivatives
+   double *psix,
+   double *psiy,
+   double *psiz,
+   double *psixx,
+   double *psixy,
+   double *psixz,
+   double *psiyy,
+   double *psiyz,
+   double *psizz,
+   double *gxx,       // metric components
+   double *gxy,
+   double *gxz,
+   double *gyy,
+   double *gyz,
+   double *gzz,
+   double *kxx,       // extrinsic curvature components
+   double *kxy,
+   double *kxz,
+   double *kyy,
+   double *kyz,
+   double *kzz);
+
   // for cleanup purposes
   void TwoPunctures_finalise(ini_data *data);
 

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -219,17 +219,17 @@ void params_alloc();
 void params_free();
 void params_read(char *fname);
 void params_write(char * fname);
-double params_get_real(char * key);
-int params_get_int(char * key);
-char *params_get_str(char * key);
-void params_setadd(char * key, int type, char *val, int addpar);
-void params_set_int(char * key, int val);
-void params_set_bool(char * key, bool val);
-void params_set_real(char * key, double val);
-void params_set_str(char * key, char* val);
-void params_add_int(char * key, int val);
-void params_add_real(char * key, double val);
-void params_add_str(char * key, char *val);
+double params_get_real(const char * key);
+int params_get_int(const char * key);
+char *params_get_str(const char * key);
+void params_setadd(const char * key, int type, const char *val, int addpar);
+void params_set_int(const char * key, int val);
+void params_set_bool(const char * key, bool val);
+void params_set_real(const char * key, double val);
+void params_set_str(const char * key, const char* val);
+void params_add_int(const char * key, int val);
+void params_add_real(const char * key, double val);
+void params_add_str(const char * key, const char *val);
 
 void make_output_dir();
 void write_derivs(derivs *u, const int n1, const int n2, const int n3,

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -69,9 +69,6 @@ enum{
   evaluation, // evaluate using all spectral coefficients (slow)
   N_interp_opt,
 };
-static const char* str_interp_opt[N_interp_opt] = {
-  "taylor", "spectral"
-};
 
 /* lapse options */
 enum{
@@ -81,9 +78,6 @@ enum{
   brownsville, // See Phys. Rev. D 74, 041501 (2006)
   N_lapse_opt,
 };
-static const char* str_lapse_opt[N_lapse_opt] = {
-  "antisymmetric", "averaged", "psin", "brownsville",
-};
 
 /* conformalfactor options */
 enum{
@@ -92,9 +86,6 @@ enum{
   FACTOR1, // CCTK_EQUALS(metric_type, "static conformal") && CCTK_EQUALS(conformal_storage, "factor+derivs")
   FACTOR2, // CCTK_EQUALS(metric_type, "static conformal") && CCTK_EQUALS(conformal_storage, "factor+derivs+2nd derivs")
   N_cf_opt,
-};
-static const char* str_cf_opt[N_cf_opt] = {
-  "nonstatic", "static0", "static01", "static012",
 };
 
 #define use_sources (0) //SB: do not add the source terms
@@ -118,9 +109,6 @@ enum{
   REAL,
   STRING,
   N_PAR_TYPES,
-};
-static const char* str_par_type[N_PAR_TYPES] = {
-  "INTEGER", "REAL", "STRING", 
 };
 
 typedef struct {

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -191,13 +191,13 @@ void Newton (int nvar, int n1, int n2, int n3, derivs *v,
 
 /* TP_Utilies.c */
 void nrerror (char error_text[]);
-int *ivector (long nl, long nh);
+int *TP_ivector (long nl, long nh);
 double *dvector (long nl, long nh);
 int **imatrix (long nrl, long nrh, long ncl, long nch);
 double **dmatrix (long nrl, long nrh, long ncl, long nch);
 double ***d3tensor (long nrl, long nrh, long ncl, long nch, long ndl,
 		    long ndh);
-void free_ivector (int *v, long nl, long nh);
+void TP_free_ivector (int *v, long nl, long nh);
 void free_dvector (double *v, long nl, long nh);
 void free_imatrix (int **m, long nrl, long nrh, long ncl, long nch);
 void free_dmatrix (double **m, long nrl, long nrh, long ncl, long nch);

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -260,10 +260,10 @@ extern "C" {
 
   // set based on input file
   void TwoPunctures_params_set_inputfile(char *inputfile);
-  void TwoPunctures_params_set_Real(char *key, double value);
-  void TwoPunctures_params_set_Int(char *key, int value);
-  void TwoPunctures_params_set_Boolean(char *key, bool value);
-  void TwoPunctures_params_set_String(char *key, char * value);
+  void TwoPunctures_params_set_Real(const char *key, double value);
+  void TwoPunctures_params_set_Int(const char *key, int value);
+  void TwoPunctures_params_set_Boolean(const char *key, bool value);
+  void TwoPunctures_params_set_String(const char *key, const char * value);
 
   ini_data * TwoPunctures_make_initial_data();
 

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -275,6 +275,7 @@ extern "C" {
   void TwoPunctures_params_set_Real(char *key, double value);
   void TwoPunctures_params_set_Int(char *key, int value);
   void TwoPunctures_params_set_Boolean(char *key, bool value);
+  void TwoPunctures_params_set_String(char *key, char * value);
 
   ini_data * TwoPunctures_make_initial_data();
 

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -178,17 +178,17 @@ void Newton (int nvar, int n1, int n2, int n3, derivs *v,
 	     double tol, int itmax);
 
 /* TP_Utilies.c */
-void nrerror (char error_text[]);
+// void nrerror (char error_text[]);
 int *TP_ivector (long nl, long nh);
-double *dvector (long nl, long nh);
-int **imatrix (long nrl, long nrh, long ncl, long nch);
-double **dmatrix (long nrl, long nrh, long ncl, long nch);
+double *TP_dvector (long nl, long nh);
+int **TP_imatrix (long nrl, long nrh, long ncl, long nch);
+double **TP_dmatrix (long nrl, long nrh, long ncl, long nch);
 double ***d3tensor (long nrl, long nrh, long ncl, long nch, long ndl,
 		    long ndh);
 void TP_free_ivector (int *v, long nl, long nh);
-void free_dvector (double *v, long nl, long nh);
-void free_imatrix (int **m, long nrl, long nrh, long ncl, long nch);
-void free_dmatrix (double **m, long nrl, long nrh, long ncl, long nch);
+void TP_free_dvector (double *v, long nl, long nh);
+void TP_free_imatrix (int **m, long nrl, long nrh, long ncl, long nch);
+void TP_free_dmatrix (double **m, long nrl, long nrh, long ncl, long nch);
 void free_d3tensor (double ***t, long nrl, long nrh, long ncl, long nch,
 		    long ndl, long ndh);
 

--- a/include/TwoPunctures.h
+++ b/include/TwoPunctures.h
@@ -313,6 +313,7 @@ extern "C" {
 
   void TwoPunctures_Cartesian_interpolation_list
   (ini_data *data,    // struct containing the previously calculated solution
+   const double* center_offset, // offset b=0 to position (x,y,z)
    int np,            // number of elements in each array that follows...
    const double *px,  // coordinates of interpolation points
    const double *py,

--- a/src/TP_Equations.c
+++ b/src/TP_Equations.c
@@ -169,7 +169,7 @@ void NonLinEquations (double rho_adm,
   double par_m_minus = params_get_real("par_m_minus");
 
   double r_plus, r_minus, psi, psi2, psi4, psi7;
-  double mu;
+  // double mu;
 
   r_plus = sqrt ((x - par_b) * (x - par_b) + y * y + z * z);
   r_minus = sqrt ((x + par_b) * (x + par_b) + y * y + z * z);

--- a/src/TP_FuncAndJacobian.c
+++ b/src/TP_FuncAndJacobian.c
@@ -180,6 +180,9 @@ void F_of_v (int nvar, int n1, int n2, int n3, derivs *v, double *F,
      at interior points and at the boundaries "+/-" 
   */
 
+  // this check resolves warning that ‘indx’ may be used uninitialized in fprintf(debugfile,...,sources[indx])
+  if (nvar <= 0) ERROR("F_of_v: nvar must be > 0");
+
   double par_b = params_get_real("par_b");
   double par_m_plus = params_get_real("par_m_plus");
   double par_m_minus = params_get_real("par_m_minus");
@@ -1025,6 +1028,11 @@ void set_initial_guess(derivs *v)
     n1 = params_get_int("npoints_A"),
     n2 = params_get_int("npoints_B"),
     n3 = params_get_int("npoints_phi");
+
+  // this check resolves warnings that ‘i3D’ and ‘phi’ may be used uninitialized in calls to rx3_To_xyz in debug output code block
+  if (n1 <= 0) ERROR("set_initial_guess: nPoints_A must be > 0");
+  if (n2 <= 0) ERROR("set_initial_guess: npoints_B must be > 0");
+  if (n3 <= 0) ERROR("set_initial_guess: npoints_phi must be > 0");
 
   double par_b = params_get_real("par_b");
 

--- a/src/TP_FuncAndJacobian.c
+++ b/src/TP_FuncAndJacobian.c
@@ -78,7 +78,7 @@ void Derivatives_AB3 (int nvar, int n1, int n2, int n3, derivs *v)
   dq = dvector (0, N);
   r = dvector (0, N);
   dr = dvector (0, N);
-  indx = ivector (0, N);
+  indx = TP_ivector (0, N);
 
   for (ivar = 0; ivar < nvar; ivar++)
   {
@@ -168,7 +168,7 @@ void Derivatives_AB3 (int nvar, int n1, int n2, int n3, derivs *v)
   free_dvector (dq, 0, N);
   free_dvector (r, 0, N);
   free_dvector (dr, 0, N);
-  free_ivector (indx, 0, N);
+  TP_free_ivector (indx, 0, N);
 }
 
 void F_of_v (int nvar, int n1, int n2, int n3, derivs *v, double *F,

--- a/src/TP_FuncAndJacobian.c
+++ b/src/TP_FuncAndJacobian.c
@@ -253,7 +253,7 @@ void F_of_v (int nvar, int n1, int n2, int n3, derivs *v, double *F,
     
   Derivatives_AB3 (nvar, n1, n2, n3, v);
 
-  double psi, psi2, psi4, psi7, r_plus, r_minus;
+  double psi, psi2, /*psi4, psi7,*/ r_plus, r_minus;
 
   char fname[STRLEN];
   FILE *debugfile = NULL;
@@ -333,8 +333,8 @@ void F_of_v (int nvar, int n1, int n2, int n3, derivs *v, double *F,
 		  0.5 * par_m_minus / r_minus +
 		  U->d0[0];
 		psi2 = psi * psi;
-		psi4 = psi2 * psi2;
-		psi7 = psi * psi2 * psi4;
+		// psi4 = psi2 * psi2;
+		// psi7 = psi * psi2 * psi4;
 		fprintf(debugfile,
 			"%.16g %.16g %.16g %.16g %.16g %.16g %.16g %.16g\n",
 			(double)x, (double)y, (double)A, (double)B,
@@ -604,7 +604,7 @@ void SetMatrix_JFD (int nvar, int n1, int n2, int n3, derivs *u,
 		    int *ncols, int **cols, double **Matrix)
 {
   int column, row, mcol;
-  int i, i1, i_0, i_1, j, j1, j_0, j_1, k, k1, k_0, k_1, N1, N2, N3,
+  int i, i1, i_0, i_1, j, j1, j_0, j_1, k, k1, k_0, k_1, N1, N2, /*N3,*/
     ivar, ivar1, ntotal = nvar * n1 * n2 * n3;
   double *values;
   derivs *dv;
@@ -614,7 +614,7 @@ void SetMatrix_JFD (int nvar, int n1, int n2, int n3, derivs *u,
 
   N1 = n1 - 1;
   N2 = n2 - 1;
-  N3 = n3 - 1;
+  // N3 = n3 - 1;
 
 #ifdef TP_OMP
 #pragma omp parallel for private (i,j,k,ivar,row) schedule(dynamic)
@@ -961,7 +961,7 @@ void SpecCoef(int n1, int n2, int n3, int nvar, double *v, double *cf)
 
   // VASILIS: Here v is a pointer to the values of the variable v at the collocation points and cf_v a pointer to the spectral coefficients that this routine calculates
 
-  int i, j, k, N, n, l, m;
+  int i, j, k, N, n, l; //, m;
   double *p, ***values3, ***values4;
 
   N=maximum3(n1,n2,n3);

--- a/src/TP_FuncAndJacobian.c
+++ b/src/TP_FuncAndJacobian.c
@@ -37,31 +37,31 @@ void allocate_derivs (derivs **v, const int n)
   if (v == NULL) ERROR("Out of memory");
   const int m = n - 1;
   (*v)->size = n;
-  (*v)->d0 = dvector (0, m);
-  (*v)->d1 = dvector (0, m);
-  (*v)->d2 = dvector (0, m);
-  (*v)->d3 = dvector (0, m);
-  (*v)->d11 = dvector (0, m);
-  (*v)->d12 = dvector (0, m);
-  (*v)->d13 = dvector (0, m);
-  (*v)->d22 = dvector (0, m);
-  (*v)->d23 = dvector (0, m);
-  (*v)->d33 = dvector (0, m);
+  (*v)->d0 = TP_dvector (0, m);
+  (*v)->d1 = TP_dvector (0, m);
+  (*v)->d2 = TP_dvector (0, m);
+  (*v)->d3 = TP_dvector (0, m);
+  (*v)->d11 = TP_dvector (0, m);
+  (*v)->d12 = TP_dvector (0, m);
+  (*v)->d13 = TP_dvector (0, m);
+  (*v)->d22 = TP_dvector (0, m);
+  (*v)->d23 = TP_dvector (0, m);
+  (*v)->d33 = TP_dvector (0, m);
 }
 
 void free_derivs (derivs * v)
 {
   const int m = v->size;
-  free_dvector (v->d0, 0, m);
-  free_dvector (v->d1, 0, m);
-  free_dvector (v->d2, 0, m);
-  free_dvector (v->d3, 0, m);
-  free_dvector (v->d11, 0, m);
-  free_dvector (v->d12, 0, m);
-  free_dvector (v->d13, 0, m);
-  free_dvector (v->d22, 0, m);
-  free_dvector (v->d23, 0, m);
-  free_dvector (v->d33, 0, m);
+  TP_free_dvector (v->d0, 0, m);
+  TP_free_dvector (v->d1, 0, m);
+  TP_free_dvector (v->d2, 0, m);
+  TP_free_dvector (v->d3, 0, m);
+  TP_free_dvector (v->d11, 0, m);
+  TP_free_dvector (v->d12, 0, m);
+  TP_free_dvector (v->d13, 0, m);
+  TP_free_dvector (v->d22, 0, m);
+  TP_free_dvector (v->d23, 0, m);
+  TP_free_dvector (v->d33, 0, m);
   free(v);
 }
 
@@ -71,13 +71,13 @@ void Derivatives_AB3 (int nvar, int n1, int n2, int n3, derivs *v)
   double *p, *dp, *d2p, *q, *dq, *r, *dr;
 
   N = maximum3 (n1, n2, n3);
-  p = dvector (0, N);
-  dp = dvector (0, N);
-  d2p = dvector (0, N);
-  q = dvector (0, N);
-  dq = dvector (0, N);
-  r = dvector (0, N);
-  dr = dvector (0, N);
+  p = TP_dvector (0, N);
+  dp = TP_dvector (0, N);
+  d2p = TP_dvector (0, N);
+  q = TP_dvector (0, N);
+  dq = TP_dvector (0, N);
+  r = TP_dvector (0, N);
+  dr = TP_dvector (0, N);
   indx = TP_ivector (0, N);
 
   for (ivar = 0; ivar < nvar; ivar++)
@@ -161,13 +161,13 @@ void Derivatives_AB3 (int nvar, int n1, int n2, int n3, derivs *v)
       }
     }
   }
-  free_dvector (p, 0, N);
-  free_dvector (dp, 0, N);
-  free_dvector (d2p, 0, N);
-  free_dvector (q, 0, N);
-  free_dvector (dq, 0, N);
-  free_dvector (r, 0, N);
-  free_dvector (dr, 0, N);
+  TP_free_dvector (p, 0, N);
+  TP_free_dvector (dp, 0, N);
+  TP_free_dvector (d2p, 0, N);
+  TP_free_dvector (q, 0, N);
+  TP_free_dvector (dq, 0, N);
+  TP_free_dvector (r, 0, N);
+  TP_free_dvector (dr, 0, N);
   TP_free_ivector (indx, 0, N);
 }
 
@@ -191,7 +191,7 @@ void F_of_v (int nvar, int n1, int n2, int n3, derivs *v, double *F,
   double al, be, A, B, X, R, x, r, phi, y, z, Am1, *values;
   derivs *U;
 
-  values = dvector (0, nvar - 1);
+  values = TP_dvector (0, nvar - 1);
   allocate_derivs (&U, nvar);
 
   double *sources;  
@@ -363,7 +363,7 @@ void F_of_v (int nvar, int n1, int n2, int n3, derivs *v, double *F,
     fclose(debugfile);
   
   free(sources);
-  free_dvector (values, 0, nvar - 1);
+  TP_free_dvector (values, 0, nvar - 1);
   free_derivs (U);
 }
 
@@ -389,7 +389,7 @@ void J_times_dv (int nvar, int n1, int n2, int n3, derivs *dv,
 #endif
   for (i = 0; i < n1; i++)
     {
-      values = dvector (0, nvar - 1);
+      values = TP_dvector (0, nvar - 1);
       allocate_derivs (&dU, nvar);
       allocate_derivs (&U, nvar);
       for (j = 0; j < n2; j++)
@@ -449,7 +449,7 @@ void J_times_dv (int nvar, int n1, int n2, int n3, derivs *dv,
 	    }
 	}
       
-      free_dvector (values, 0, nvar - 1);
+      TP_free_dvector (values, 0, nvar - 1);
       free_derivs (dU);
       free_derivs (U);
     }
@@ -612,7 +612,7 @@ void SetMatrix_JFD (int nvar, int n1, int n2, int n3, derivs *u,
   double *values;
   derivs *dv;
 
-  values = dvector (0, nvar - 1);
+  values = TP_dvector (0, nvar - 1);
   allocate_derivs (&dv, ntotal);
 
   N1 = n1 - 1;
@@ -692,7 +692,7 @@ void SetMatrix_JFD (int nvar, int n1, int n2, int n3, derivs *u,
 	}
     }
   free_derivs (dv);
-  free_dvector (values, 0, nvar - 1);
+  TP_free_dvector (values, 0, nvar - 1);
 }
 
 double PunctEvalAtArbitPosition (double *v, int ivar, double A, double B, double phi,
@@ -705,9 +705,9 @@ double PunctEvalAtArbitPosition (double *v, int ivar, double A, double B, double
   double *p, *values1, **values2, result;
   
   N = maximum3 (n1, n2, n3);
-  p = dvector (0, N);
-  values1 = dvector (0, N);
-  values2 = dmatrix (0, N, 0, N);
+  p = TP_dvector (0, N);
+  values1 = TP_dvector (0, N);
+  values2 = TP_dmatrix (0, N, 0, N);
   
   for (k = 0; k < n3; k++)
     {
@@ -732,9 +732,9 @@ double PunctEvalAtArbitPosition (double *v, int ivar, double A, double B, double
   fourft (values1, n3, 0);
   result = fourev (values1, n3, phi);
   
-  free_dvector (p, 0, N);
-  free_dvector (values1, 0, N);
-  free_dmatrix (values2, 0, N, 0, N);
+  TP_free_dvector (p, 0, N);
+  TP_free_dvector (values1, 0, N);
+  TP_free_dmatrix (values2, 0, N, 0, N);
   
   return result;
 }
@@ -886,9 +886,9 @@ double  PunctEvalAtArbitPositionFast (double *v, int ivar, double A, double B, d
 
   N = maximum3 (n1, n2, n3);
 
-  p = dvector (0, N);
-  values1 = dvector (0, N);
-  values2 = dmatrix (0, N, 0, N);
+  p = TP_dvector (0, N);
+  values1 = TP_dvector (0, N);
+  values2 = TP_dmatrix (0, N, 0, N);
 
   for (k = 0; k < n3; k++)
   {
@@ -912,9 +912,9 @@ double  PunctEvalAtArbitPositionFast (double *v, int ivar, double A, double B, d
   //  fourft (values1, n3, 0);
   result = fourev (values1, n3, phi);
 
-  free_dvector (p, 0, N);
-  free_dvector (values1, 0, N);
-  free_dmatrix (values2, 0, N, 0, N);
+  TP_free_dvector (p, 0, N);
+  TP_free_dvector (values1, 0, N);
+  TP_free_dmatrix (values2, 0, N, 0, N);
 
   return result;
   //  */
@@ -968,7 +968,7 @@ void SpecCoef(int n1, int n2, int n3, int nvar, double *v, double *cf)
   double *p, ***values3, ***values4;
 
   N=maximum3(n1,n2,n3);
-  p=dvector(0,N);
+  p=TP_dvector(0,N);
   values3=d3tensor(0,n1,0,n2,0,n3);
   values4=d3tensor(0,n1,0,n2,0,n3);
 
@@ -1015,7 +1015,7 @@ for (int ivar=0; ivar<nvar; ivar++){
 
 }
 
-  free_dvector(p,0,N);
+  TP_free_dvector(p,0,N);
   free_d3tensor(values3,0,n1,0,n2,0,n3);
   free_d3tensor(values4,0,n1,0,n2,0,n3);
 

--- a/src/TP_FuncAndJacobian.c
+++ b/src/TP_FuncAndJacobian.c
@@ -385,7 +385,7 @@ void J_times_dv (int nvar, int n1, int n2, int n3, derivs *dv,
   Derivatives_AB3 (nvar, n1, n2, n3, dv);
   
 #ifdef TP_OMP
-#pragma omp parallel for private (values,dU,U,i,j,k,al,A,be,B,phi,X,R,x,r,y,z,Am1,ivar,indx,par_b) schedule(dynamic)
+#pragma omp parallel for private (values,dU,U,i,j,k,al,A,be,B,phi,X,R,x,r,y,z,Am1,ivar,indx) firstprivate(par_b) schedule(dynamic)
 #endif
   for (i = 0; i < n1; i++)
     {

--- a/src/TP_Newton.c
+++ b/src/TP_Newton.c
@@ -290,7 +290,7 @@ TestRelax (int nvar, int n1, int n2, int n3, derivs *v,
 
   JFD = dmatrix (0, ntotal - 1, 0, maxcol - 1);
   cols = imatrix (0, ntotal - 1, 0, maxcol - 1);
-  ncols = ivector (0, ntotal - 1);
+  ncols = TP_ivector (0, ntotal - 1);
 
   F_of_v (nvar, n1, n2, n3, v, F, u);
 
@@ -322,7 +322,7 @@ TestRelax (int nvar, int n1, int n2, int n3, derivs *v,
 
   free_dmatrix (JFD, 0, ntotal - 1, 0, maxcol - 1);
   free_imatrix (cols, 0, ntotal - 1, 0, maxcol - 1);
-  free_ivector (ncols, 0, ntotal - 1);
+  TP_free_ivector (ncols, 0, ntotal - 1);
 }
 
 /* --------------------------------------------------------------------------*/
@@ -347,7 +347,7 @@ bicgstab (int const nvar, int const n1, int const n2, int const n3,
 
   JFD = dmatrix (0, ntotal - 1, 0, maxcol - 1);
   cols = imatrix (0, ntotal - 1, 0, maxcol - 1);
-  ncols = ivector (0, ntotal - 1);
+  ncols = TP_ivector (0, ntotal - 1);
 
   F_of_v (nvar, n1, n2, n3, v, F, u);
   SetMatrix_JFD (nvar, n1, n2, n3, u, ncols, cols, JFD);
@@ -506,7 +506,7 @@ bicgstab (int const nvar, int const n1, int const n2, int const n3,
   
   free_dmatrix (JFD, 0, ntotal - 1, 0, maxcol - 1);
   free_imatrix (cols, 0, ntotal - 1, 0, maxcol - 1);
-  free_ivector (ncols, 0, ntotal - 1);
+  TP_free_ivector (ncols, 0, ntotal - 1);
   
   if (*normres <= tol)
     return 0;

--- a/src/TP_Newton.c
+++ b/src/TP_Newton.c
@@ -284,12 +284,12 @@ TestRelax (int nvar, int n1, int n2, int n3, derivs *v,
   double *F, *res, **JFD;
   derivs *u;
 
-  F = dvector (0, ntotal - 1);
-  res = dvector (0, ntotal - 1);
+  F = TP_dvector (0, ntotal - 1);
+  res = TP_dvector (0, ntotal - 1);
   allocate_derivs (&u, ntotal);
 
-  JFD = dmatrix (0, ntotal - 1, 0, maxcol - 1);
-  cols = imatrix (0, ntotal - 1, 0, maxcol - 1);
+  JFD = TP_dmatrix (0, ntotal - 1, 0, maxcol - 1);
+  cols = TP_imatrix (0, ntotal - 1, 0, maxcol - 1);
   ncols = TP_ivector (0, ntotal - 1);
 
   F_of_v (nvar, n1, n2, n3, v, F, u);
@@ -316,12 +316,12 @@ TestRelax (int nvar, int n1, int n2, int n3, derivs *v,
   printf ("After: |F|=%20.15e\n", (double) norm1 (res, ntotal));
   fflush(stdout);
 
-  free_dvector (F, 0, ntotal - 1);
-  free_dvector (res, 0, ntotal - 1);
+  TP_free_dvector (F, 0, ntotal - 1);
+  TP_free_dvector (res, 0, ntotal - 1);
   free_derivs (u);
 
-  free_dmatrix (JFD, 0, ntotal - 1, 0, maxcol - 1);
-  free_imatrix (cols, 0, ntotal - 1, 0, maxcol - 1);
+  TP_free_dmatrix (JFD, 0, ntotal - 1, 0, maxcol - 1);
+  TP_free_imatrix (cols, 0, ntotal - 1, 0, maxcol - 1);
   TP_free_ivector (ncols, 0, ntotal - 1);
 }
 
@@ -342,27 +342,27 @@ bicgstab (int const nvar, int const n1, int const n2, int const n3,
   double *F;
   derivs *u, *ph, *sh;
 
-  F = dvector (0, ntotal - 1);
+  F = TP_dvector (0, ntotal - 1);
   allocate_derivs (&u, ntotal);
 
-  JFD = dmatrix (0, ntotal - 1, 0, maxcol - 1);
-  cols = imatrix (0, ntotal - 1, 0, maxcol - 1);
+  JFD = TP_dmatrix (0, ntotal - 1, 0, maxcol - 1);
+  cols = TP_imatrix (0, ntotal - 1, 0, maxcol - 1);
   ncols = TP_ivector (0, ntotal - 1);
 
   F_of_v (nvar, n1, n2, n3, v, F, u);
   SetMatrix_JFD (nvar, n1, n2, n3, u, ncols, cols, JFD);
 
   /* temporary storage */
-  r = dvector (0, ntotal - 1);
-  p = dvector (0, ntotal - 1);
+  r = TP_dvector (0, ntotal - 1);
+  p = TP_dvector (0, ntotal - 1);
   allocate_derivs (&ph, ntotal);
-  /*ph  = dvector(0, ntotal-1);*/
-  rt = dvector (0, ntotal - 1);
-  s = dvector (0, ntotal - 1);
+  /*ph  = TP_dvector(0, ntotal-1);*/
+  rt = TP_dvector (0, ntotal - 1);
+  s = TP_dvector (0, ntotal - 1);
   allocate_derivs (&sh, ntotal);
-  /*sh  = dvector(0, ntotal-1);*/
-  t = dvector (0, ntotal - 1);
-  vv = dvector (0, ntotal - 1);
+  /*sh  = TP_dvector(0, ntotal-1);*/
+  t = TP_dvector (0, ntotal - 1);
+  vv = TP_dvector (0, ntotal - 1);
   
   /* check */
   if (output == 1) {
@@ -490,22 +490,22 @@ bicgstab (int const nvar, int const n1, int const n2, int const n3,
   } //   if (*normres > tol) 
   
   /* free temporary storage */
-  free_dvector (r, 0, ntotal - 1);
-  free_dvector (p, 0, ntotal - 1);
-  /*free_dvector(ph,  0, ntotal-1);*/
+  TP_free_dvector (r, 0, ntotal - 1);
+  TP_free_dvector (p, 0, ntotal - 1);
+  /*TP_free_dvector(ph,  0, ntotal-1);*/
   free_derivs (ph);
-  free_dvector (rt, 0, ntotal - 1);
-  free_dvector (s, 0, ntotal - 1);
-  /*free_dvector(sh,  0, ntotal-1);*/
+  TP_free_dvector (rt, 0, ntotal - 1);
+  TP_free_dvector (s, 0, ntotal - 1);
+  /*TP_free_dvector(sh,  0, ntotal-1);*/
   free_derivs (sh);
-  free_dvector (t, 0, ntotal - 1);
-  free_dvector (vv, 0, ntotal - 1);
+  TP_free_dvector (t, 0, ntotal - 1);
+  TP_free_dvector (vv, 0, ntotal - 1);
   
-  free_dvector (F, 0, ntotal - 1);
+  TP_free_dvector (F, 0, ntotal - 1);
   free_derivs (u);
   
-  free_dmatrix (JFD, 0, ntotal - 1, 0, maxcol - 1);
-  free_imatrix (cols, 0, ntotal - 1, 0, maxcol - 1);
+  TP_free_dmatrix (JFD, 0, ntotal - 1, 0, maxcol - 1);
+  TP_free_imatrix (cols, 0, ntotal - 1, 0, maxcol - 1);
   TP_free_ivector (ncols, 0, ntotal - 1);
   
   if (*normres <= tol)
@@ -538,7 +538,7 @@ Newton (int const nvar, int const n1, int const n2, int const n3,
   double *F, dmax, normres;
   derivs *u, *dv;
   
-  F = dvector (0, ntotal - 1);
+  F = TP_dvector (0, ntotal - 1);
   allocate_derivs (&dv, ntotal);
   allocate_derivs (&u, ntotal);
   
@@ -587,7 +587,7 @@ Newton (int const nvar, int const n1, int const n2, int const n3,
   
   fflush(stdout);
   
-  free_dvector (F, 0, ntotal - 1);
+  TP_free_dvector (F, 0, ntotal - 1);
   free_derivs (dv);
   free_derivs (u);
 }

--- a/src/TP_Newton.c
+++ b/src/TP_Newton.c
@@ -534,7 +534,7 @@ Newton (int const nvar, int const n1, int const n2, int const n3,
 {
   int verbose = params_get_int("verbose");
   
-  int ntotal = n1 * n2 * n3 * nvar, ii, it;
+  int ntotal = n1 * n2 * n3 * nvar, /*ii,*/ it;
   double *F, dmax, normres;
   derivs *u, *dv;
   
@@ -565,7 +565,7 @@ Newton (int const nvar, int const n1, int const n2, int const n3,
       }
       
       fflush(stdout);
-      ii =
+      // ii =
 	bicgstab (nvar, n1, n2, n3, v, dv, verbose, 100, dmax * 1.e-3, &normres);
 #ifdef TP_OMP
 #pragma omp parallel for

--- a/src/TP_Utilities.c
+++ b/src/TP_Utilities.c
@@ -585,7 +585,7 @@ void params_write(char * fname)
 }
 
 /* get double */
-double params_get_real(char * key)
+double params_get_real(const char * key)
 {
   for (int i =0; i < params->n; i++)  {
     if (STREQL(key,params->key[i])) {
@@ -599,7 +599,7 @@ double params_get_real(char * key)
 }
 
 /* get int */
-int params_get_int(char * key) 
+int params_get_int(const char * key) 
 {
   for (int i =0; i < params->n; i++)  {
     if (STREQL(key,params->key[i])) {
@@ -613,7 +613,7 @@ int params_get_int(char * key)
 }
 
 /* get string */
-char * params_get_str(char * key)
+char * params_get_str(const char * key)
 {
   for (int i =0; i < params->n; i++)  {
     if (STREQL(key,params->key[i])) {
@@ -627,7 +627,7 @@ char * params_get_str(char * key)
 }
 
 /* set parameter */
-void params_setadd(char * key, int type, char* val, int addpar)
+void params_setadd(const char * key, int type, const char* val, int addpar)
 {
 #define check_unique (0) // addpar=1 assumes parameter is not there,
 			 // activate this if you need to enforce this.
@@ -665,25 +665,25 @@ void params_setadd(char * key, int type, char* val, int addpar)
    Note: addpar=0 does not set the type
 */
 
-void params_set_int(char * key, int val) {
+void params_set_int(const char * key, int val) {
   char cval[STRLEN];
   sprintf(cval, "%d", val);
   params_setadd(key, INTEGER, cval, 0); 
 }
  
-void params_set_bool(char * key, bool val) {
+void params_set_bool(const char * key, bool val) {
   char cval[STRLEN];
   sprintf(cval, "%d", val?1:0);
   params_setadd(key, INTEGER, cval, 0); 
 }
 
-void params_set_real(char * key, double val) {
+void params_set_real(const char * key, double val) {
   char cval[STRLEN];
   sprintf(cval, "%.16e", val);
   params_setadd(key, REAL, cval, 0); 
 }
 
-void params_set_str(char * key, char *val) {
+void params_set_str(const char * key, const char *val) {
   params_setadd(key, STRING, val, 0);
 }
 
@@ -691,7 +691,7 @@ void params_set_str(char * key, char *val) {
    New parameter, append
  */
 
-void params_add_int(char * key, int val) {
+void params_add_int(const char * key, int val) {
   char cval[STRLEN];
   sprintf(cval, "%d", val);
   params_setadd(key, INTEGER, cval, 1);
@@ -703,13 +703,13 @@ void params_add_bool(char * key, bool val) {
   params_setadd(key, INTEGER, cval, 1); 
 }
 
-void params_add_real(char * key, double val) {
+void params_add_real(const char * key, double val) {
   char cval[STRLEN];
   sprintf(cval, "%.16e", val);
   params_setadd(key, REAL, cval, 1);
 }
 
-void params_add_str(char * key, char *val) {
+void params_add_str(const char * key, const char *val) {
   params_setadd(key, STRING, val, 1);
 }
 

--- a/src/TP_Utilities.c
+++ b/src/TP_Utilities.c
@@ -370,6 +370,9 @@ fourft (double *u, int N, int inv)
   int l, k, iy, M;
   double x, x1, fac, Pi_fac, *a, *b;
   
+  // this check resolves warning that ‘a[0]’ and ‘a[M]’ may be used uninitialized in the inv==0 code block
+  if (N < 0) ERROR("fourft: number of points must be >= 0");
+
   M = N / 2;
   a = dvector (0, M);
   b = dvector (1, M);		/* Actually: b=vector(1,M-1) but this is problematic if M=1*/

--- a/src/TP_Utilities.c
+++ b/src/TP_Utilities.c
@@ -6,6 +6,22 @@
 
 #include "TwoPunctures.h"
 
+// static const char* str_interp_opt[N_interp_opt] = {
+//   "taylor", "spectral"
+// };
+
+// static const char* str_lapse_opt[N_lapse_opt] = {
+//   "antisymmetric", "averaged", "psin", "brownsville",
+// };
+
+// static const char* str_cf_opt[N_cf_opt] = {
+//   "nonstatic", "static0", "static01", "static012",
+// };
+
+static const char* str_par_type[N_PAR_TYPES] = {
+  "INTEGER", "REAL", "STRING", 
+};
+
 /* -------------------------------------------------------------------------*/
 
 int *

--- a/src/TP_Utilities.c
+++ b/src/TP_Utilities.c
@@ -9,14 +9,14 @@
 /* -------------------------------------------------------------------------*/
 
 int *
-ivector (long nl, long nh)
+TP_ivector (long nl, long nh)
 /* allocate an int vector with subscript range v[nl..nh] */
 {
   int *retval;
 
   retval = malloc(sizeof(int)*(nh-nl+1));
   if(retval == NULL)
-    ERROR ("allocation failure in ivector()");
+    ERROR ("allocation failure in TP_ivector()");
   return retval - nl;
 }
 
@@ -135,8 +135,8 @@ d3tensor (long nrl, long nrh, long ncl, long nch, long ndl, long ndh)
 }
 
 void
-free_ivector (int *v, long nl, long nh)
-/* free an int vector allocated with ivector() */
+TP_free_ivector (int *v, long nl, long nh)
+/* free an int vector allocated with TP_ivector() */
 {
   free(v+nl);
 }

--- a/src/TP_Utilities.c
+++ b/src/TP_Utilities.c
@@ -37,31 +37,31 @@ TP_ivector (long nl, long nh)
 }
 
 double *
-dvector (long nl, long nh)
+TP_dvector (long nl, long nh)
 /* allocate a double vector with subscript range v[nl..nh] */
 {
   double *retval;
 
   retval = malloc(sizeof(double)*(nh-nl+1));
   if(retval == NULL)
-    ERROR ("allocation failure in dvector()");
+    ERROR ("allocation failure in TP_dvector()");
   return retval - nl;
 }
 
 int **
-imatrix (long nrl, long nrh, long ncl, long nch)
+TP_imatrix (long nrl, long nrh, long ncl, long nch)
 /* allocate a int matrix with subscript range m[nrl..nrh][ncl..nch] */
 {
   int **retval;
 
   retval = malloc(sizeof(int *)*(nrh-nrl+1));
   if(retval == NULL)
-    ERROR ("allocation failure (1) in imatrix()");
+    ERROR ("allocation failure (1) in TP_imatrix()");
   
   /* get all memory for the matrix in on chunk */
   retval[0] = malloc(sizeof(int)*(nrh-nrl+1)*(nch-ncl+1));
   if(retval[0] == NULL)
-    ERROR ("allocation failure (2) in imatrix()");
+    ERROR ("allocation failure (2) in TP_imatrix()");
 
   /* apply column and row offsets */
   retval[0] -= ncl;
@@ -77,19 +77,19 @@ imatrix (long nrl, long nrh, long ncl, long nch)
 }
 
 double **
-dmatrix (long nrl, long nrh, long ncl, long nch)
+TP_dmatrix (long nrl, long nrh, long ncl, long nch)
 /* allocate a double matrix with subscript range m[nrl..nrh][ncl..nch] */
 {
   double **retval;
 
   retval = malloc(sizeof(double *)*(nrh-nrl+1));
   if(retval == NULL)
-    ERROR ("allocation failure (1) in dmatrix()");
+    ERROR ("allocation failure (1) in TP_dmatrix()");
 
   /* get all memory for the matrix in on chunk */
   retval[0] = malloc(sizeof(double)*(nrh-nrl+1)*(nch-ncl+1));
   if(retval[0] == NULL)
-    ERROR ("allocation failure (2) in dmatrix()");
+    ERROR ("allocation failure (2) in TP_dmatrix()");
 
   /* apply column and row offsets */
   retval[0] -= ncl;
@@ -158,23 +158,23 @@ TP_free_ivector (int *v, long nl, long nh)
 }
 
 void
-free_dvector (double *v, long nl, long nh)
-/* free an double vector allocated with dvector() */
+TP_free_dvector (double *v, long nl, long nh)
+/* free an double vector allocated with TP_dvector() */
 {
   free(v+nl);
 }
 
 void
-free_imatrix (int **m, long nrl, long nrh, long ncl, long nch)
-/* free an int matrix allocated by imatrix() */
+TP_free_imatrix (int **m, long nrl, long nrh, long ncl, long nch)
+/* free an int matrix allocated by TP_imatrix() */
 {
   free(m[nrl]+ncl);
   free(m+nrl);
 }
 
 void
-free_dmatrix (double **m, long nrl, long nrh, long ncl, long nch)
-/* free a double matrix allocated by dmatrix() */
+TP_free_dmatrix (double **m, long nrl, long nrh, long ncl, long nch)
+/* free a double matrix allocated by TP_dmatrix() */
 {
   free(m[nrl]+ncl);
   free(m+nrl);
@@ -248,7 +248,7 @@ chebft_Zeros (double u[], int n, int inv)
   int k, j, isignum;
   double fac, sum, Pion, *c;
   
-  c = dvector (0, n);
+  c = TP_dvector (0, n);
   Pion = Pi / n;
   if (inv == 0)
     {
@@ -284,7 +284,7 @@ chebft_Zeros (double u[], int n, int inv)
     else
 #endif
       u[j] = c[j];
-  free_dvector (c, 0, n);
+  TP_free_dvector (c, 0, n);
 }
 
 void
@@ -294,7 +294,7 @@ chebft_Extremes (double u[], int n, int inv)
   int k, j, isignum, N = n - 1;
   double fac, sum, PioN, *c;
 
-  c = dvector (0, N);
+  c = TP_dvector (0, N);
   PioN = Pi / N;
   if (inv == 0)
   {
@@ -326,7 +326,7 @@ chebft_Extremes (double u[], int n, int inv)
   }
   for (j = 0; j < n; j++)
     u[j] = c[j];
-  free_dvector (c, 0, N);
+  TP_free_dvector (c, 0, N);
 }
 
 void
@@ -374,8 +374,8 @@ fourft (double *u, int N, int inv)
   if (N < 0) ERROR("fourft: number of points must be >= 0");
 
   M = N / 2;
-  a = dvector (0, M);
-  b = dvector (1, M);		/* Actually: b=vector(1,M-1) but this is problematic if M=1*/
+  a = TP_dvector (0, M);
+  b = TP_dvector (1, M);		/* Actually: b=vector(1,M-1) but this is problematic if M=1*/
   fac = 1. / M;
   Pi_fac = Pi * fac;
   if (inv == 0)
@@ -424,8 +424,8 @@ fourft (double *u, int N, int inv)
       iy = -iy;
     }
   }
-  free_dvector (a, 0, M);
-  free_dvector (b, 1, M);
+  TP_free_dvector (a, 0, M);
+  TP_free_dvector (b, 1, M);
 }
 
 void

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -423,10 +423,11 @@ void TwoPunctures_Cartesian_interpolation
   // This function builds a list of points from the given Cartesian cordinates
   // and then calls TwoPunctures_Cartesian_interpolation_list.
 
-  double center_offset[3];
-  center_offset[0] = params_get_real("center_offset1");
-  center_offset[1] = params_get_real("center_offset2");
-  center_offset[2] = params_get_real("center_offset3");
+  const double center_offset[3] ={
+    params_get_real("center_offset1"),
+    params_get_real("center_offset2"),
+    params_get_real("center_offset3")
+  };
 
   const int xxx = nxyz[0];
   const int xxxyyy = nxyz[0]*nxyz[1];
@@ -444,9 +445,9 @@ void TwoPunctures_Cartesian_interpolation
         const int ind = i + xxx * j + xxxyyy* k;
 
         double xx, yy, zz;
-        px[ind] = x[i] - center_offset[0];
-        py[ind] = y[j] - center_offset[1];
-        pz[ind] = z[k] - center_offset[2];
+        px[ind] = x[i];
+        py[ind] = y[j];
+        pz[ind] = z[k];
 
       } /* for i */
     }   /* for j */
@@ -454,6 +455,7 @@ void TwoPunctures_Cartesian_interpolation
 
   TwoPunctures_Cartesian_interpolation_list
     (data,
+     center_offset,
      np, x, y, z,
      /* outputs */
      alp,
@@ -471,6 +473,7 @@ void TwoPunctures_Cartesian_interpolation
 /* Given a list of ntotal interpolation points, interpolate data to each listed point. */
 void TwoPunctures_Cartesian_interpolation_list
 (ini_data *data,    // struct containing the previously calculated solution
+ const double* center_offset, // offset b=0 to position (x,y,z)
  int np,            // number of elements in each array that follows...
  const double *px,  // coordinates of interpolation points
  const double *py,
@@ -597,9 +600,9 @@ void TwoPunctures_Cartesian_interpolation_list
   for (int ind = 0; ind < np; ind++) {
 
         double xx, yy, zz;
-        xx = px[ind];
-        yy = py[ind];
-        zz = pz[ind];
+        xx = px[ind] - center_offset[0];
+        yy = py[ind] - center_offset[1];
+        zz = pz[ind] - center_offset[2];
 
         /* We implement swapping the x and z coordinates as follows.
            The bulk of the code that performs the actual calculations

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -156,7 +156,7 @@ ini_data* TwoPunctures_make_initial_data() {
 
   const int verbose = params_get_int("verbose");
 
-  char outdir[STRLEN];
+  // char outdir[STRLEN];
   if (params_get_int("do_residuum_debug_output")+
       params_get_int("do_initial_debug_output")+
       params_get_int("do_solution_file_output")+
@@ -164,33 +164,33 @@ ini_data* TwoPunctures_make_initial_data() {
     make_output_dir();
   }
   
-  double par_P_plus[3], par_P_minus[3];
-  par_P_plus[0] = params_get_real("par_P_plus1");
-  par_P_plus[1] = params_get_real("par_P_plus2");
-  par_P_plus[2] = params_get_real("par_P_plus3");
-  par_P_minus[0] = params_get_real("par_P_minus1");
-  par_P_minus[1] = params_get_real("par_P_minus2");
-  par_P_minus[2] = params_get_real("par_P_minus3");
+  // double par_P_plus[3], par_P_minus[3];
+  // par_P_plus[0] = params_get_real("par_P_plus1");
+  // par_P_plus[1] = params_get_real("par_P_plus2");
+  // par_P_plus[2] = params_get_real("par_P_plus3");
+  // par_P_minus[0] = params_get_real("par_P_minus1");
+  // par_P_minus[1] = params_get_real("par_P_minus2");
+  // par_P_minus[2] = params_get_real("par_P_minus3");
 
-  double par_S_plus[3], par_S_minus[3];
-  par_S_plus[0] = params_get_real("par_S_plus1");
-  par_S_plus[1] = params_get_real("par_S_plus2");
-  par_S_plus[2] = params_get_real("par_S_plus3");
-  par_S_minus[0] = params_get_real("par_S_minus1");
-  par_S_minus[1] = params_get_real("par_S_minus2");
-  par_S_minus[2] = params_get_real("par_S_minus3");
+  // double par_S_plus[3], par_S_minus[3];
+  // par_S_plus[0] = params_get_real("par_S_plus1");
+  // par_S_plus[1] = params_get_real("par_S_plus2");
+  // par_S_plus[2] = params_get_real("par_S_plus3");
+  // par_S_minus[0] = params_get_real("par_S_minus1");
+  // par_S_minus[1] = params_get_real("par_S_minus2");
+  // par_S_minus[2] = params_get_real("par_S_minus3");
 
   double par_b = params_get_real("par_b");
 
-  double center_offset[3];
-  center_offset[0] = params_get_real("center_offset1");
-  center_offset[1] = params_get_real("center_offset2");
-  center_offset[2] = params_get_real("center_offset3");
+  // double center_offset[3];
+  // center_offset[0] = params_get_real("center_offset1");
+  // center_offset[1] = params_get_real("center_offset2");
+  // center_offset[2] = params_get_real("center_offset3");
 
   // ---------------------------------------------------
 
-  double E; // ADM energy of the Bowen-York spacetime"
-  double J1, J2, J3; // Angular momentum of the Bowen-York spacetime"
+  // double E; // ADM energy of the Bowen-York spacetime"
+  // double J1, J2, J3; // Angular momentum of the Bowen-York spacetime"
   double mp = params_get_real("par_m_plus"), mm = params_get_real("par_m_minus"); // Bare masses of the punctures
   double mp_adm, mm_adm; // ADM masses of the punctures (measured at the other spatial infinities
   double admMass;
@@ -331,11 +331,11 @@ ini_data* TwoPunctures_make_initial_data() {
     admMass = (mp + mm - 4*par_b*PunctEvalAtArbitPosition(v->d0, 0, 1, 0, 0, nvar, n1, n2, n3));
     if (verbose) printf ("The total ADM mass is %g\n", admMass);
 
-    E = admMass;
+    // E = admMass;
 
-    J1 = -(center_offset[2]*par_P_minus[1]) + center_offset[1]*par_P_minus[2] - center_offset[2]*par_P_plus[1] + center_offset[1]*par_P_plus[2] + par_S_minus[0] + par_S_plus[0];
-    J2 = center_offset[2]*par_P_minus[0] - center_offset[0]*par_P_minus[2] + par_b*par_P_minus[2] + center_offset[2]*par_P_plus[0] - center_offset[0]*par_P_plus[2] - par_b*par_P_plus[2] + par_S_minus[1] + par_S_plus[1];
-    J3 = -(center_offset[1]*par_P_minus[0]) + center_offset[0]*par_P_minus[1] - par_b*par_P_minus[1] - center_offset[1]*par_P_plus[0] + center_offset[0]*par_P_plus[1] + par_b*par_P_plus[1] + par_S_minus[2] + par_S_plus[2];
+    // J1 = -(center_offset[2]*par_P_minus[1]) + center_offset[1]*par_P_minus[2] - center_offset[2]*par_P_plus[1] + center_offset[1]*par_P_plus[2] + par_S_minus[0] + par_S_plus[0];
+    // J2 = center_offset[2]*par_P_minus[0] - center_offset[0]*par_P_minus[2] + par_b*par_P_minus[2] + center_offset[2]*par_P_plus[0] - center_offset[0]*par_P_plus[2] - par_b*par_P_plus[2] + par_S_minus[1] + par_S_plus[1];
+    // J3 = -(center_offset[1]*par_P_minus[0]) + center_offset[0]*par_P_minus[1] - par_b*par_P_minus[1] - center_offset[1]*par_P_plus[0] + center_offset[0]*par_P_plus[1] + par_b*par_P_plus[1] + par_S_minus[2] + par_S_plus[2];
 
   }
 
@@ -444,7 +444,7 @@ void TwoPunctures_Cartesian_interpolation
         //const int ind = GFINDEX3D (i, j, k, nshift, mshift);
         const int ind = i + xxx * j + xxxyyy* k;
 
-        double xx, yy, zz;
+        // double xx, yy, zz;
         px[ind] = x[i];
         py[ind] = y[j];
         pz[ind] = z[k];
@@ -513,11 +513,11 @@ void TwoPunctures_Cartesian_interpolation_list
   /* derivs cf_v = *(data.cf_v); */
   /* int ntotal = data.ntotal; */
   //SB:
-  double *F = data->F; 
-  derivs *u = data->u; 
+  // double *F = data->F; 
+  // derivs *u = data->u; 
   derivs *v = data->v;
   derivs *cf_v = data->cf_v; 
-  int ntotal = data->ntotal; 
+  // int ntotal = data->ntotal; 
   
   // ---- prepare required parameters
   double par_b = params_get_real("par_b");

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -475,9 +475,9 @@ void TwoPunctures_Cartesian_interpolation_list
 (ini_data *data,    // struct containing the previously calculated solution
  const double* center_offset, // offset b=0 to position (x,y,z)
  int np,            // number of elements in each array that follows...
- const double *px,  // coordinates of interpolation points
- const double *py,
- const double *pz,
+ const double *x,  // coordinates of interpolation points
+ const double *y,
+ const double *z,
  double *alp,       // lapse
  double *psi,       // conformal factor and derivatives
  double *psix,
@@ -600,9 +600,9 @@ void TwoPunctures_Cartesian_interpolation_list
   for (int ind = 0; ind < np; ind++) {
 
         double xx, yy, zz;
-        xx = px[ind] - center_offset[0];
-        yy = py[ind] - center_offset[1];
-        zz = pz[ind] - center_offset[2];
+        xx = x[ind] - center_offset[0];
+        yy = y[ind] - center_offset[1];
+        zz = z[ind] - center_offset[2];
 
         /* We implement swapping the x and z coordinates as follows.
            The bulk of the code that performs the actual calculations

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -24,28 +24,28 @@ static void _dealloc_params_mem_if_req(){
 
 /* Control interaction with internal parameters in the following */ //
 
-void TwoPunctures_params_set_Real(char *key, double value){
+void TwoPunctures_params_set_Real(const char *key, double value){
   /*
     Set parameters according to input.
   */
   params_set_real(key, value);       // replace, don't append new
 }
 
-void TwoPunctures_params_set_Int(char *key, int value){
+void TwoPunctures_params_set_Int(const char *key, int value){
   /*
     Set parameters according to input.
   */
   params_set_int(key, value);   // replace, don't append new
 }
 
-void TwoPunctures_params_set_Boolean(char *key, bool value){
+void TwoPunctures_params_set_Boolean(const char *key, bool value){
   /*
     Set parameters according to input.
   */
   params_set_bool(key, value);   // replace, don't append new
 }
 
-void TwoPunctures_params_set_String(char *key, char * value){
+void TwoPunctures_params_set_String(const char *key, const char * value){
   /*
     Set parameters according to input.
   */

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -213,7 +213,7 @@ ini_data* TwoPunctures_make_initial_data() {
     double up, um;
 
     /* Solve only when called for the first time */
-    F = dvector (0, ntotal - 1);
+    F = TP_dvector (0, ntotal - 1);
     allocate_derivs (&u, ntotal);
     allocate_derivs (&v, ntotal);
     allocate_derivs (&cf_v, ntotal);
@@ -361,7 +361,7 @@ ini_data* TwoPunctures_make_initial_data() {
   }
   
   /*
-    free_dvector (F, 0, ntotal - 1);
+    TP_free_dvector (F, 0, ntotal - 1);
     free_derivs (u);
     free_derivs (v);
     free_derivs (cf_v);

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -67,7 +67,7 @@ void TwoPunctures_params_set_inputfile(char* inputfile){
     char od[STRLEN];//SB: this can be improved.
     int n = strlen(inputfile);
     if (STREQL(inputfile+(n-4),".par")) {
-      strncpy (od,inputfile,n-4);
+      strncpy (od,inputfile,STRLEN);
       od[n-4] = '\0';
       //printf("%s\n",s);
       params_set_str("outputdir",od); 

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -124,6 +124,7 @@ void TwoPunctures_params_set_default(){
   params_add_int("do_initial_debug_output",0); // Output debug information about initial guess
   params_add_int("do_solution_file_output",0); // output .data files
   params_add_int("do_bam_file_output",0); // output input files for bam's puncture_ps
+  params_add_int("output_derivatives_order",0); // include 0,1,2 derivatives with do_solution_file_output
   
   // Interpolation
   params_add_int("grid_setup_method",taylor_expansion); // How to fill the 3D grid from the spectral grid ?
@@ -339,15 +340,16 @@ ini_data* TwoPunctures_make_initial_data() {
   }
 
   if (params_get_int("do_solution_file_output")) {
+    int output_derivatives_order = params_get_int("output_derivatives_order");
     /* Output the solution */    
     write_derivs( u, n1,n2,n3, 
-		  0, // =0,1,2 derivatives to output
+		  output_derivatives_order, // =0,1,2 derivatives to output
 		  "u.data");
     write_derivs( v, n1,n2,n3, 
-		  0, // =0,1,2 derivatives to output
+		  output_derivatives_order, // =0,1,2 derivatives to output
 		  "v.data");
     write_derivs( cf_v, n1,n2,n3, 
-		  0, // =0,1,2 derivatives to output
+		  output_derivatives_order, // =0,1,2 derivatives to output
 		  "cf_v.data");
   }
 

--- a/src/TwoPunctures.c
+++ b/src/TwoPunctures.c
@@ -456,7 +456,7 @@ void TwoPunctures_Cartesian_interpolation
   TwoPunctures_Cartesian_interpolation_list
     (data,
      center_offset,
-     np, x, y, z,
+     np, px, py, pz,
      /* outputs */
      alp,
      psi, 


### PR DESCRIPTION
**Important: PLEASE MODIFY THE TARGET BRANCH ON THIS PR BEFORE ACCEPTING.**

Florida Atlantic University's [nmesh](https://arxiv.org/pdf/2212.06340) program is using the TwoPuncturesC library to implement a module that can (i) use initial data that has been previously computed and saved by external TwoPuncturesC-based programs, and (ii) generate (and optionally save) initial data on the fly during an nmesh run.

Summary of changes:

1. **Renamed common Numerical Recipes functions to include the prefix "TP_".**
This is a breaking change for clients that rely on TwoPuncturesC as their source for Numerical Recipes functions. A linker conflict was occurring when client programs (e.g. nmesh) also have their own copy of NR functions. This was resolved by adding the prefix "TP_" to each function in TwoPuncturesC's copy, effectively making each private. For example: `void TP_free_ivector (int *v, long nl, long nh);`

2. **Added new function `TwoPunctures_Cartesian_interpolation_list` that accepts an arbitrary list of interpolation points.**
The original function, `TwoPunctures_Cartesian_interpolation` (without the `_list` suffix) accepts 3 lists (x, y and z) of Cartesian axis values, and then iterates over the 3D points spanned by the lists. The new implementation is such that one of these functions is a thin wrapper around the other; i.e. the core code has not been copy/pasted and remains unchanged.

3. **Added new parameter `output_derivatives_order`, with values 0 (default), 1 or 2.**
This feature support the ability to round-trip (i.e. save, and then later use) initial data for scenarios that additionally require first or second order derivatives; for example when a non-default value of parameter `conformal_state` is used. The ability to write multiple orders of derivatives was already in function `write_derivs` (which creates output files `u.data`, `v.data` and `cf_v.data`) but was being called with a hard-coded value of 0; the new parameter value replaces the hard-coded value.

4. **Compiled with important warning messages enabled, and resolved each warning.**
See `Makefile` for a full list of the warning flags that were switched on; the ones that resulted in code changes were `-Wall`, `-Wwrite-strings` and `-Wshadow`. Here is a summary of the types of changes: 
* Most warning fixes were trivial, but may look large because of the large number of lines that were touched by the find-replace operation. For example the `params_get_<type>` family of functions needed `const` added to `char*` arguments because they were being called with literal string values.
* Many fixes involved commenting out (never deleting) unused declarations of variables, and the unused lines of code that used them. For example the calculation of the angular momentum (J1, J2 and J3) of the Bowen-York spacetime. The optimizer was already removing this code; commenting it out simply made it explicit in source.
* Non-trivial fixes pertained to the use of what the compiler thought were uninitialized variables. All variables were determined to be, in fact, properly initialized (i.e. not "bugs") but this was not always obvious to the compiler. For example, consider the line of code `for (i=0; i<n; i++)`, where both `i` and `n` are `int` variables, and the body of the for-loop is used to initialize a variable. If `n` were zero or negative then the for-loop body would never execute and the variable would be left uninitialized. The compiler cannot verify that `n` is positive-definite when it is passed in via an argument. We developers can tell because we have knowledge of the full scope of calls made to the function. The fix was to assert `n>0` prior to the for-loop, and call `exit(0)` if not.